### PR TITLE
Providers: Fixing data race conditions

### DIFF
--- a/providers/twitter/twitter_test.go
+++ b/providers/twitter/twitter_test.go
@@ -32,11 +32,11 @@ func Test_Implements_Provider(t *testing.T) {
 }
 
 func Test_BeginAuth(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	mockTwitter(func(ts *httptest.Server) {
 		provider := twitterProvider()
+
 		session, err := provider.BeginAuth("state")
 		s := session.(*Session)
 		a.NoError(err)
@@ -56,13 +56,11 @@ func Test_BeginAuth(t *testing.T) {
 }
 
 func Test_FetchUser(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	mockTwitter(func(ts *httptest.Server) {
 		provider := twitterProvider()
 		session := Session{AccessToken: &oauth.AccessToken{Token: "TOKEN", Secret: "SECRET"}}
-
 		user, err := provider.FetchUser(&session)
 		a.NoError(err)
 

--- a/providers/xero/xero_test.go
+++ b/providers/xero/xero_test.go
@@ -32,7 +32,6 @@ func Test_Implements_Provider(t *testing.T) {
 }
 
 func Test_BeginAuth(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	mockXero(func(ts *httptest.Server) {
@@ -50,9 +49,7 @@ func Test_BeginAuth(t *testing.T) {
 }
 
 func Test_FetchUser(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
-
 	mockXero(func(ts *httptest.Server) {
 		provider := xeroProvider()
 		session := Session{AccessToken: &oauth.AccessToken{Token: "TOKEN", Secret: "SECRET"}}


### PR DESCRIPTION
Removing unnecessary t.Parallel() calls in tests that use *httptest.Server
That underline pointer will also panic otherwise.  Adding a mutex to guard
updates to the pointer struts.  Luckily, only two of the very many providers
where flagged with race conditions. Now that the test are green I can make the
minor change for instagram auth flow