### PR TITLE
Gothic: Attempts to normalize the padding around the base64 string

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -215,7 +215,15 @@ func validateState(req *http.Request, sess goth.Session) error {
 	}
 
 	originalState := authURL.Query().Get("state")
-	if originalState != "" && (originalState != req.URL.Query().Get("state")) {
+	requestState := req.URL.Query().Get("state")
+	// check to see if the length is not the same
+	// if they aren't try trimming the padding to fix a potential instagram bug
+	if len(originalState) != len(requestState) {
+		originalState = strings.TrimRight(originalState, "=")
+		requestState = strings.TrimRight(requestState, "=")
+	}
+
+	if originalState != "" && (originalState != requestState) {
 		return errors.New("state token mismatch")
 	}
 	return nil


### PR DESCRIPTION
This should help with Instagram state issues where padding is missing
from one of the tokens.  This fixes timehop/tickets#2055 and may address
timehop/tickets#1941